### PR TITLE
Added new placeholders

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,7 @@ dependencies {
     compileOnly("io.lumine:Mythic-Dist:5.6.1")
     compileOnly("com.github.Xiao-MoMi:Custom-Fishing:2.3.3")
     compileOnly("com.sk89q.worldguard:worldguard-bukkit:7.0.7")
-    compileOnly("io.lumine:MythicLib-dist:1.6.2-SNAPSHOT")
+    compileOnly("io.lumine:MythicLib-dist:1.7.1-SNAPSHOT")
     compileOnly("net.Indyuce:MMOItems-API:6.10-SNAPSHOT")
     compileOnly("io.th0rgal:oraxen:2.0-SNAPSHOT")
     compileOnly("com.sarry20:TopMinion:2.4.3")

--- a/src/main/java/gg/auroramc/collections/collection/Collection.java
+++ b/src/main/java/gg/auroramc/collections/collection/Collection.java
@@ -100,6 +100,10 @@ public class Collection {
         return getPlayerLevel(player) >= getMaxLevel();
     }
 
+    public boolean isUnlocked(Player player) {
+        return getCount(player) > 0;
+    }
+
     public void removeProgress(Player player, int amount) {
         var user = AuroraAPI.getUserManager().getUser(player);
         if (!user.isLoaded()) return;

--- a/src/main/java/gg/auroramc/collections/collection/CollectionManager.java
+++ b/src/main/java/gg/auroramc/collections/collection/CollectionManager.java
@@ -288,7 +288,9 @@ public class CollectionManager implements Listener {
 
         var collectionsInCategory = plugin.getCollectionManager().getCollectionsByCategory(category);
         var maxedCollections = collectionsInCategory.stream().filter(c -> c.isMaxed(player)).count();
+        var unlockedCollections = collectionsInCategory.stream().filter(c -> c.isUnlocked(player)).count();
         var maxedPercent = Math.min((double) maxedCollections / collectionsInCategory.size(), 1);
+        var unlockedPercent = Math.min((double) unlockedCollections / collectionsInCategory.size(), 1);
 
         var config = plugin.getConfigManager().getCategoriesMenuConfig();
         var bar = config.getProgressBar();
@@ -302,6 +304,9 @@ public class CollectionManager implements Listener {
         var maxedCompletedPcs = ((Double) Math.floor(pcs * maxedCompletedPercent)).intValue();
         var maxedRemainingPcs = pcs - maxedCompletedPcs;
 
+        var unlockedCompletedPcs = ((Double) Math.floor(pcs * unlockedPercent)).intValue();
+        var unlockedRemainingPcs = pcs - unlockedCompletedPcs;
+
         placeholders.add(Placeholder.of("{name}", categoryName));
         placeholders.add(Placeholder.of("{progress_percent}", currentPercentage));
         placeholders.add(Placeholder.of("{progressbar}", bar.getFilledCharacter().repeat(completedPcs) + bar.getUnfilledCharacter().repeat(remainingPcs) + "&r"));
@@ -309,6 +314,32 @@ public class CollectionManager implements Listener {
         placeholders.add(Placeholder.of("{maxed_collection_count}", AuroraAPI.formatNumber(maxedCollections)));
         placeholders.add(Placeholder.of("{total_collection_count}", AuroraAPI.formatNumber(collectionsInCategory.size())));
         placeholders.add(Placeholder.of("{maxed_progress_percent}", AuroraAPI.formatNumber(maxedPercent * 100)));
+        placeholders.add(Placeholder.of("{unlocked_collection_count}", AuroraAPI.formatNumber(unlockedCollections)));
+        placeholders.add(Placeholder.of("{unlocked_progressbar}", bar.getFilledCharacter().repeat(unlockedCompletedPcs) + bar.getUnfilledCharacter().repeat(unlockedRemainingPcs) + "&r"));
+        placeholders.add(Placeholder.of("{unlocked_progress_percent}", AuroraAPI.formatNumber(unlockedPercent * 100)));
+
+        return placeholders;
+    }
+
+    public List<Placeholder<?>> getGlobalPlaceholders(Player player) {
+        List<Placeholder<?>> placeholders = new ArrayList<>();
+
+        var allCollections = plugin.getCollectionManager().getAllCollections();
+        var unlockedCollections = allCollections.stream().filter(c -> c.isUnlocked(player)).count();
+        var totalCollections = allCollections.size();
+
+        var unlockedPercent = totalCollections > 0 ? (double) unlockedCollections / totalCollections : 0;
+
+        var config = plugin.getConfigManager().getCategoriesMenuConfig();
+        var bar = config.getProgressBar();
+        var pcs = bar.getLength();
+        var completedPcs = (int) Math.floor(pcs * unlockedPercent);
+        var remainingPcs = pcs - completedPcs;
+
+        placeholders.add(Placeholder.of("{unlocked_total_count}", AuroraAPI.formatNumber(unlockedCollections)));
+        placeholders.add(Placeholder.of("{total_all_collection_count}", AuroraAPI.formatNumber(totalCollections)));
+        placeholders.add(Placeholder.of("{unlocked_total_progressbar}", bar.getFilledCharacter().repeat(completedPcs) + bar.getUnfilledCharacter().repeat(remainingPcs) + "&r"));
+        placeholders.add(Placeholder.of("{unlocked_total_percent}", AuroraAPI.formatNumber(unlockedPercent * 100)));
 
         return placeholders;
     }

--- a/src/main/java/gg/auroramc/collections/menu/CategoryMenu.java
+++ b/src/main/java/gg/auroramc/collections/menu/CategoryMenu.java
@@ -35,13 +35,16 @@ public class CategoryMenu {
             menu.addFiller(ItemBuilder.filler(Material.AIR));
         }
 
+        var globalPlaceholders = plugin.getCollectionManager().getGlobalPlaceholders(player);
+
         for (var customItem : config.getCustomItems().values()) {
-            menu.addItem(ItemBuilder.of(customItem).build(player));
+            menu.addItem(ItemBuilder.of(customItem).placeholder(globalPlaceholders).build(player));
         }
 
         for (var item : config.getItems().entrySet()) {
             var category = item.getKey();
             var placeholders = plugin.getCollectionManager().getCategoryPlaceholders(category, player);
+            placeholders.addAll(globalPlaceholders);
 
             menu.addItem(ItemBuilder.of(item.getValue()).placeholder(placeholders).build(player),
                     (e) -> {

--- a/src/main/java/gg/auroramc/collections/placeholder/CollectionsPlaceholderHandler.java
+++ b/src/main/java/gg/auroramc/collections/placeholder/CollectionsPlaceholderHandler.java
@@ -30,8 +30,20 @@ public class CollectionsPlaceholderHandler implements PlaceholderHandler {
     @Override
     public String onPlaceholderRequest(Player player, String[] args) {
         if (args.length < 3) return null;
+
         var manager = plugin.getCollectionManager();
-        var romanNumeral = plugin.getConfigManager().getCollectionMenuConfig().getForceRomanNumerals();
+        var config = plugin.getConfigManager();
+
+        var allCollections = manager.getAllCollections();
+        var unlockedCollections = allCollections.stream().filter(c -> c.isUnlocked(player)).count();
+        var totalCollections = allCollections.size();
+        var unlockedPercent = totalCollections > 0 ? (double) unlockedCollections / totalCollections : 0;
+        var bar = config.getCategoriesMenuConfig().getProgressBar();
+        var pcs = bar.getLength();
+        var completedPcs = (int) Math.floor(pcs * unlockedPercent);
+        var remainingPcs = pcs - completedPcs;
+
+        var romanNumeral = config.getCollectionMenuConfig().getForceRomanNumerals();
         var full = String.join("_", args);
 
         if (args[0].equals("category")) {
@@ -92,6 +104,16 @@ public class CollectionsPlaceholderHandler implements PlaceholderHandler {
             var collection = getCollection(Arrays.copyOf(args, args.length - 1));
             if (collection == null) return null;
             return collection.getConfig().getName();
+        } else if (args[0].equals("unlocked")) {
+            if (full.endsWith("count_total")) {
+                return AuroraAPI.formatNumber(unlockedCollections);
+            } else if (full.endsWith("count_total_all_collection")) {
+                return AuroraAPI.formatNumber(totalCollections);
+            } else if (full.endsWith("total_progressbar")) {
+                return bar.getFilledCharacter().repeat(completedPcs) + bar.getUnfilledCharacter().repeat(remainingPcs) + "&r";
+            } else if (full.endsWith("total_percent")) {
+                return AuroraAPI.formatNumber(unlockedPercent * 100);
+            }
         }
 
         return null;
@@ -133,7 +155,11 @@ public class CollectionsPlaceholderHandler implements PlaceholderHandler {
                         c.getCategory() + "_" + c.getId() + "_count",
                         c.getCategory() + "_" + c.getId() + "_count_raw",
                         c.getCategory() + "_" + c.getId() + "_next_count",
-                        c.getCategory() + "_" + c.getId() + "_next_count_raw"))
+                        c.getCategory() + "_" + c.getId() + "_next_count_raw",
+                        "unlocked_count_total",
+                        "unlocked_count_total_all_collection",
+                        "unlocked_total_progressbar",
+                        "unlocked_total_percent"))
                 .toList();
     }
 }

--- a/src/main/java/gg/auroramc/collections/placeholder/CollectionsPlaceholderHandler.java
+++ b/src/main/java/gg/auroramc/collections/placeholder/CollectionsPlaceholderHandler.java
@@ -143,7 +143,8 @@ public class CollectionsPlaceholderHandler implements PlaceholderHandler {
     public List<String> getPatterns() {
         var manager = plugin.getCollectionManager();
 
-        return manager.getAllCollections().stream().flatMap(c -> Stream.of(
+        return Stream.concat(
+                manager.getAllCollections().stream().flatMap(c -> Stream.of(
                         "category_" + c.getCategory() + "_level",
                         "category_" + c.getCategory() + "_level_raw",
                         "category_" + c.getCategory() + "_max_level",
@@ -155,11 +156,14 @@ public class CollectionsPlaceholderHandler implements PlaceholderHandler {
                         c.getCategory() + "_" + c.getId() + "_count",
                         c.getCategory() + "_" + c.getId() + "_count_raw",
                         c.getCategory() + "_" + c.getId() + "_next_count",
-                        c.getCategory() + "_" + c.getId() + "_next_count_raw",
+                        c.getCategory() + "_" + c.getId() + "_next_count_raw"
+                )),
+                Stream.of(
                         "unlocked_count_total",
                         "unlocked_count_total_all_collection",
                         "unlocked_total_progressbar",
-                        "unlocked_total_percent"))
-                .toList();
+                        "unlocked_total_percent"
+                )
+        ).toList();
     }
 }


### PR DESCRIPTION
Added new placeholders to calculate progress based on unlocked collections.

These can be used on **category items**
- {unlocked_collection_count}
- {unlocked_progressbar}
- {unlocked_progress_percent}

These can be used on **custom-items**
- {unlocked_total_count}
- {total_all_collection_count}
- {unlocked_total_progressbar}
- {unlocked_total_percent}

**Global placeholders**
%aurora_collections_unlocked_total_percent%
%aurora_collections_unlocked_total_progressbar%
%aurora_collections_unlocked_count_total%
%aurora_collections_unlocked_count_total_all_collection%

MythicLib library updated.